### PR TITLE
PRODENG-291 Add logic to use ruleset tag by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ steps:
       create-github-annotations: "true" # Whether to create annotations using the GitHub Advanced Security (nb. this is not free for private repositories)
       fail-on-new-issues: "true" # Whether the introduction of new issues should cause the build to fail.
       pmd-ruleset-repo: "Alfresco/pmd-ruleset" # The GitHub repository containing the PMD ruleset (by default https://github.com/Alfresco/pmd-ruleset/).
-      pmd-ruleset-ref: "master" # The git reference (e.g. branch name, tag name or commit id) for the ruleset project.
+      pmd-ruleset-ref-override: "" # A git reference (e.g. branch name, tag name or commit id) for the ruleset project. If this is not provided then the default is the latest tag alphabetically with the name starting with the PMD version (for example this could be a tag 7.1.0_20240723 if pmd-version is set to 7.1.0) and falling back to the default commit checked out by a clone.
       pmd-ruleset-path: "pmd-ruleset.xml" # The path to the PMD ruleset file from the root of the ruleset project. Optionally other paths to local rulesets can be appended to this separated by commas.
       classpath-enable: "true" # Whether to set the classpath before the scan (used by certain rules - for example MissingOverride). This assumes the project uses maven.
       classpath-build-command: "mvn -ntp test-compile" # Command to build the class files so that the classpath can be used.

--- a/action.yml
+++ b/action.yml
@@ -25,11 +25,13 @@ inputs:
       The GitHub repository containing the PMD ruleset.
     required: false
     default: "Alfresco/pmd-ruleset"
-  pmd-ruleset-ref:
+  pmd-ruleset-ref-override:
     description: |
-      The git reference (e.g. branch name or commit id) for the Alfresco/pmd-ruleset project.
+      A git reference (e.g. branch name, tag name or commit id) for the ruleset project. If this is not provided then the
+      default is the latest tag alphabetically with the name starting with the PMD version (for example this could be a
+      tag 7.1.0_20240723 if pmd-version is set to 7.1.0) and falling back to the default commit checked out by a clone.
     required: false
-    default: "master"
+    default: ""
   pmd-ruleset-path:
     description: |
       The path to the PMD ruleset file from the root of the ruleset project. Optionally other paths to local rulesets
@@ -65,8 +67,27 @@ runs:
       uses: actions/checkout@v4
       with:
         repository: ${{ inputs.pmd-ruleset-repo }}
-        ref: ${{ inputs.pmd-ruleset-ref }}
         path: pmd-ruleset
+        fetch-depth: 0
+
+    - name: Determine ruleset ref to checkout
+      id: find-ruleset-ref
+      run: |
+        cd pmd-ruleset;
+        if [[ -z "${{ inputs.pmd-ruleset-ref-override }}" ]]; then
+          echo "No ruleset ref override provided, finding latest tag starting with PMD version: ${{ inputs.pmd-version }}";
+          ruleset_ref="$(git tag --list --sort=-taggerdate "${{ inputs.pmd-version }}*" | head -1)";
+        else
+          echo "Using ruleset ref override: ${{ inputs.pmd-ruleset-ref-override }}";
+          ruleset_ref=${{ inputs.pmd-ruleset-ref-override }};
+        fi
+        if [[ -z "$ruleset_ref" ]]; then
+          echo "No ruleset ref found, falling back to HEAD.";
+          ruleset_ref=HEAD;
+        fi
+        echo "Checking out ruleset ref: ${ruleset_ref}";
+        git checkout $ruleset_ref;
+      shell: bash
 
     - name: Install PMD
       run: |


### PR DESCRIPTION
Repositories can still pin to a particular version or commit if they want.